### PR TITLE
Adding link to requirements document

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ Install ghc and dependencies. You need to have [stack](https://www.haskellstack.
 * `stack install`
 
 ## Contributing
+* [Elm Language Server - Requirements](https://docs.google.com/document/d/1ETeZeN17hqM4yui4iqBv1jwO8HryDZyel2kdcxTCGGA/edit)
 * Get information about contributing on the [\#elm-language-server channel](https://elmlang.slack.com/messages/elm-language-server) in the elm slack.


### PR DESCRIPTION
I saw this document passing by on the #elm-language-server Slack channel. Since this is not in the README, here is the link in the Contributing section.